### PR TITLE
Add Sphinx Documentation for Django_Capstone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ Thumbs.db
 .vscode/
 *.swp
 *~
+docs/_build/
+make.bat
+Makefile
+.env
+*.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,0 +1,49 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Django_C'
+copyright = '2025, Zohaib Muhammad'
+author = 'Zohaib Muhammad'
+release = '1.0'
+
+# -- Django Integration ------------------------------------------------------
+# Ensures Django is properly set up for documentation generation
+
+import os
+import sys
+import django
+
+sys.path.insert(0, os.path.abspath('..'))  # Adjust path if needed
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'portfolio_project.settings')  # Ensure this matches your actual project name
+
+django.setup()
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',      # Automatically generate documentation from docstrings
+    'sphinx.ext.viewcode',     # Adds links to source code
+    'sphinx.ext.napoleon'      # Supports Google & NumPy-style docstrings
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']
+
+# -- Output directory configuration -----------------------------------------
+# Ensures generated documentation is stored in a dedicated folder
+
+html_output_path = '../docs'  # Stores documentation in the `docs` folder
+
+

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,0 +1,17 @@
+.. Django_C documentation master file, created by
+   sphinx-quickstart on Sun May 18 14:35:42 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Django_C documentation
+======================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+


### PR DESCRIPTION
### Overview
This pull request adds the Sphinx documentation setup for Django_Capstone. It includes configuration files, a Makefile, and `.gitignore` updates.

### Changes Made:
✅ Added Sphinx source files for generating project documentation.  
✅ Created `Makefile` and `make.bat` for automated documentation builds.  
✅ Updated `.gitignore` to exclude unnecessary files.  
✅ Configured `conf.py` to integrate Django with Sphinx documentation.  
✅ Added an `index.rst` file for structured documentation navigation.

### Why These Changes?
📌 Helps automate and structure project documentation.  
📌 Provides clear developer guidance through reStructuredText format.  
📌 Ensures Django is properly configured within the documentation system.

### Next Steps:
After merging, contributors should run the following to build docs:
```bash
cd docs
make html
